### PR TITLE
Adapt for HA 2026.06

### DIFF
--- a/packages/rctpower.yaml
+++ b/packages/rctpower.yaml
@@ -45,11 +45,9 @@ input_select:
       - "5: Schedule"
     icon: "mdi:strategy"
 
-switch:
-  - platform: template
-    switches:
-      rct_lock_battery:
-        friendly_name: Lock battery
+template:
+  - switch:
+      - name: "Lock battery"
         unique_id: rct_lock_battery
         turn_on:
           - action: switch.turn_off
@@ -70,8 +68,7 @@ switch:
               object_value: >
                 {{ states('input_select.rct_soc_strategy_selector').split(':')[0] }}
       
-      rct_max_charge:
-        friendly_name: QuickCharge battery
+      - name: "QuickCharge battery"
         unique_id: rct_quickcharge_battery
         turn_on:
           - action: switch.turn_off
@@ -91,9 +88,8 @@ switch:
               object_name: "power_mng.soc_strategy"
               object_value: >
                 {{ states('input_select.rct_soc_strategy_selector').split(':')[0] }}
-
-      rct_use_grid_power:
-        friendly_name: Use Grid Power
+    
+      - name: "Use Grid Power"
         unique_id: rct_use_grid_power
         # icon: battery-charging
         turn_on:
@@ -106,7 +102,6 @@ switch:
             data:
               object_name: "power_mng.use_grid_power_enable"
               object_value: "False"
-
 
 automation:
   - alias: "set_rct_soc_max"


### PR DESCRIPTION
Fixes do-gooder/rctpower_writesupport#41

> The legacy template platform syntax under the individual platform keys has been removed. [...] Move your template entities to the modern template: syntax

Very lightly tested, it loads again and at least the Lock Battery Button does what it is supposed to do.