### PR TITLE
fix: validate response frame object id and CRC in the get path

### DIFF
--- a/rct.py
+++ b/rct.py
@@ -15,6 +15,7 @@ import socket
 import select
 import time
 
+from rctclient.exceptions import FrameCRCMismatch
 from rctclient.frame import make_frame, ReceiveFrame
 from rctclient.registry import REGISTRY
 from rctclient.types import Command
@@ -106,9 +107,17 @@ def send_data(host_port: tuple[str, int], data: bytes) -> None:
 
 
 def communicate_with_server(
-    host_port, send_frame, response_data_type, retries=3, timeout=5
+    host_port, send_frame, response_data_type, expected_id=None, retries=3, timeout=5
 ):
-    """Exchange frames with the inverter and decode the response."""
+    """Exchange frames with the inverter and decode the response.
+
+    Only a complete, CRC-valid frame whose object id matches expected_id is
+    accepted. The inverter shares one stream with unsolicited frames and can
+    deliver responses meant for other connected clients (see
+    python-rctclient issue #43) — decoding the first complete frame
+    regardless of id returns values belonging to a different register.
+    Mismatched frames are discarded and reading continues until the deadline.
+    """
     for attempt in range(retries):
         print(
             f"Attempting connection to {host_port} (Attempt {attempt + 1}/{retries})..."
@@ -120,27 +129,46 @@ def communicate_with_server(
                 sock.sendall(send_frame)
                 print("*** Frame sent. Waiting for response...")
 
+                deadline = time.time() + timeout
+                pending = b""
                 response_frame = ReceiveFrame()
-                buffer_size = 256
-                while not response_frame.complete():
-                    ready_read, _, _ = select.select([sock], [], [], timeout)
-                    if ready_read:
-                        buf = sock.recv(buffer_size)
-                        if buf:
-                            response_frame.consume(buf)
-                        else:
+                while time.time() < deadline:
+                    if pending:
+                        chunk, pending = pending, b""
+                    else:
+                        remaining = max(0.1, deadline - time.time())
+                        ready_read, _, _ = select.select([sock], [], [], remaining)
+                        if not ready_read:
+                            continue
+                        chunk = sock.recv(256)
+                        if not chunk:
                             print("ERROR: Remote host closed the connection.")
                             break
-                    else:
-                        print("ERROR: Response timeout, retrying...")
-                        break
-
-                if response_frame.complete():
-                    decoded_value = decode_value(
-                        response_data_type, response_frame.data
-                    )
+                    try:
+                        consumed = response_frame.consume(chunk)
+                    except FrameCRCMismatch as e:
+                        # Resync past the corrupt frame, keep the tail.
+                        consumed = getattr(e, "consumed_bytes", 0) or 1
+                        response_frame = ReceiveFrame()
+                        pending = chunk[consumed:]
+                        continue
+                    pending = chunk[consumed:]
+                    if not response_frame.complete():
+                        continue
+                    frame, response_frame = response_frame, ReceiveFrame()
+                    if not frame.crc_ok:
+                        continue
+                    if expected_id is not None and frame.id != expected_id:
+                        print(
+                            f"*** Ignoring frame for object 0x{frame.id:08X}"
+                            f" (expected 0x{expected_id:08X})"
+                        )
+                        continue
+                    decoded_value = decode_value(response_data_type, frame.data)
                     print(f"*** Response: {decoded_value}")
                     return decoded_value
+                else:
+                    print("ERROR: Response timeout, retrying...")
 
             except (socket.timeout, socket.gaierror, socket.error) as e:
                 print(f"ERROR: Socket issue: {e}")
@@ -252,7 +280,12 @@ def get_value(parameter: str, host: str) -> str:
     host_port = (host, DEFAULT_PORT)
     object_info = REGISTRY.get_by_name(parameter)
     frame = make_frame(command=Command.READ, id=object_info.object_id)
-    result = communicate_with_server(host_port, frame, object_info.response_data_type)
+    result = communicate_with_server(
+        host_port,
+        frame,
+        object_info.response_data_type,
+        expected_id=object_info.object_id,
+    )
 
     if result is not None:
         return f"*** READ SUCCESS: {parameter} = {result}"

--- a/rct.py
+++ b/rct.py
@@ -129,14 +129,14 @@ def communicate_with_server(
                 sock.sendall(send_frame)
                 print("*** Frame sent. Waiting for response...")
 
-                deadline = time.time() + timeout
+                deadline = time.monotonic() + timeout
                 pending = b""
                 response_frame = ReceiveFrame()
-                while time.time() < deadline:
+                while time.monotonic() < deadline:
                     if pending:
                         chunk, pending = pending, b""
                     else:
-                        remaining = max(0.1, deadline - time.time())
+                        remaining = max(0.0, deadline - time.monotonic())
                         ready_read, _, _ = select.select([sock], [], [], remaining)
                         if not ready_read:
                             continue


### PR DESCRIPTION
The inverter shares one stream with unsolicited frames and can deliver responses meant for other connected clients (python-rctclient [issue #43](https://github.com/svalouch/python-rctclient/issues/43); the rctclient protocol docs carry the same warning). `communicate_with_server` decoded the **first complete frame regardless of its object id**, so `get` could silently return a value belonging to a different register — e.g. `power_mng.soc_strategy` reading `0` instead of `5` whenever another client (the Home Assistant [rct-power integration](https://github.com/weltenwort/home-assistant-rct-power-integration)) was polling concurrently. In a drift-detection setup this caused endless spurious re-writes.

Verified live on a Power Storage 6.0: without the check roughly every other read returned a crossed value; with it, consecutive reads are stable and the log shows the foreign frames being discarded:

```
*** Ignoring frame for object 0x65EED11B (expected 0xF168B748)
*** READ SUCCESS: power_mng.soc_strategy = 5
```

Changes:
- accept only a complete frame with matching object id and valid CRC
- resync past CRC-mismatched frames and keep the remaining bytes
- keep reading until the timeout deadline instead of failing on the first foreign frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)
