### PR TITLE
feat: battery cell monitoring + calibration-on-demand support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Valid Parameters:
   buf_v_control.power_reduction - External power reduction based on solar plant peak power
     Valid Range: 0.00 to 1.00, with at most two decimal places
     Default Value: 1.00
+  battery.soc_target - Current SOC target
+    Valid Range: 0.00 to 1.00, with at most two decimal places (get/set)
+  battery.soc_target_high - SOC target band upper bound (get only)
+  battery.soc_target_low - SOC target band lower bound (get only)
+  power_mng.bat_next_calib_date - Next battery calibration (unix timestamp)
+    Setting a date ~2 days in the past starts a calibration immediately
 ```
 
 ## Homeassistant Integration with pyscript (Alternative 1)
@@ -191,6 +197,43 @@ homeassistant:
 ![image](<images/packages_result.png>)
 
 ### 
+## Battery cell monitoring (rct_cells.py)
+
+`rct_cells.py` reads **live per-cell voltages and temperatures** of every
+battery module plus stack health registers (`battery.ah_capacity`,
+`battery.soh`, `battery.soc`, per-module `battery.stack_cycles[n]`) over one
+TCP connection and prints a single JSON line:
+
+```
+python rct_cells.py --host=192.168.0.99 --modules=4
+{"cell_min_mv": 3292, "cell_max_mv": 3330, "cell_spread_mv": 38, "cells_read": 96, "ah_capacity": 16.138, "soh": 1.0, ...}
+```
+
+The undocumented `battery.cells[N]` register decodes as 24 records of 4 bytes
+per module — `[temperature_c: uint8][voltage_mv: uint16 LE][flag: uint8]`
+(verified against `battery.min_cell_voltage` / `battery.max_cell_voltage`
+and `battery.temperature` on a Power Storage 6.0).
+
+Why you want this: cell **imbalance** silently eats usable capacity (the BMS
+`ah_capacity` estimate shrinks while `soh` stays 1.0) — e.g. after a battery
+extension the new module runs at a higher SOC than the old ones and
+terminates charging for the whole stack early. Watching per-module
+averages/spreads makes that visible immediately, and long-term per-cell
+logging shows individual cell aging. A healthy pack sits below ~25 mV
+spread; ≥50 mV is worth documenting for a warranty case.
+
+- **Home Assistant**: see `packages/rctpower_cells.yaml` for a ready-made
+  command_line + template sensor package (15-min polling).
+- **Long-term per-cell logging**: add `--vm-url=http://<host>:8428` to push
+  every cell as `rct_cell_voltage_mv{module,cell}` / `rct_cell_temp_c{...}`
+  in Prometheus text format to VictoriaMetrics (or anything exposing
+  `/api/v1/import/prometheus`).
+- **Calibration on demand**: the inverter recalibrates its SOC anchor by
+  charging to 100 % (default every ~30 days). To start one right now:
+  `python rct.py set power_mng.bat_next_calib_date $(($(date +%s) - 172800)) --host=...`
+  — the battery icon shows "Charge Calib" while it runs. Balancing follows
+  the calibration and shows as SOC target 100 % for up to a few days.
+
 ## Links
 [Rctclient's documentation](https://rctclient.readthedocs.io/en/latest/index.html)
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ homeassistant:
 
 ![image](<images/packages_result.png>)
 
-### 
 ## Battery cell monitoring (rct_cells.py)
 
 `rct_cells.py` reads **live per-cell voltages and temperatures** of every

--- a/packages/rctpower_cells.yaml
+++ b/packages/rctpower_cells.yaml
@@ -1,0 +1,82 @@
+# Home Assistant package: RCT battery cell-level monitoring.
+#
+# Polls rct_cells.py every 15 minutes (one TCP connection per poll) and lifts
+# the stack/per-module aggregates into template sensors with state_class so
+# Home Assistant keeps long-term statistics. Adjust the host IP, the number
+# of modules and (optionally) add --vm-url=http://<victoriametrics>:8428 to
+# also record every single cell voltage/temperature long-term.
+#
+# Copy rct_cells.py to /config/ (next to rct.py) first.
+
+command_line:
+  - sensor:
+      name: rct_battery_cells_json
+      unique_id: rct_battery_cells_json
+      command: "python /config/rct_cells.py --host=192.168.0.99 --modules=4"
+      scan_interval: 900
+      command_timeout: 150
+      unit_of_measurement: "mV"
+      value_template: >-
+        {%- if value is defined and value[:1] == '{' -%}
+          {{ (value | from_json).cell_spread_mv }}
+        {%- else -%}unknown{%- endif -%}
+      json_attributes:
+        - cell_min_mv
+        - cell_max_mv
+        - cell_spread_mv
+        - cells_read
+        - ah_capacity
+        - soh
+        - soc
+        - battery_temp_c
+        - module_1_cycles
+        - module_2_cycles
+        - module_3_cycles
+        - module_4_cycles
+        - module_1_avg_mv
+        - module_1_spread_mv
+        - module_2_avg_mv
+        - module_2_spread_mv
+        - module_3_avg_mv
+        - module_3_spread_mv
+        - module_4_avg_mv
+        - module_4_spread_mv
+
+template:
+  - sensor:
+      - name: "RCT Cell Voltage Min"
+        unique_id: rct_cell_voltage_min
+        unit_of_measurement: "mV"
+        state_class: measurement
+        availability: "{{ state_attr('sensor.rct_battery_cells_json', 'cell_min_mv') is not none }}"
+        state: "{{ state_attr('sensor.rct_battery_cells_json', 'cell_min_mv') }}"
+      - name: "RCT Cell Voltage Max"
+        unique_id: rct_cell_voltage_max
+        unit_of_measurement: "mV"
+        state_class: measurement
+        availability: "{{ state_attr('sensor.rct_battery_cells_json', 'cell_max_mv') is not none }}"
+        state: "{{ state_attr('sensor.rct_battery_cells_json', 'cell_max_mv') }}"
+      - name: "RCT Cell Voltage Spread"
+        unique_id: rct_cell_voltage_spread
+        unit_of_measurement: "mV"
+        state_class: measurement
+        availability: "{{ state_attr('sensor.rct_battery_cells_json', 'cell_spread_mv') is not none }}"
+        state: "{{ state_attr('sensor.rct_battery_cells_json', 'cell_spread_mv') }}"
+      # Duplicate the block below per module as needed (module_2_..., etc.).
+      - name: "RCT Module 1 Cell Voltage Avg"
+        unique_id: rct_module_1_cell_voltage_avg
+        unit_of_measurement: "mV"
+        state_class: measurement
+        availability: "{{ state_attr('sensor.rct_battery_cells_json', 'module_1_avg_mv') is not none }}"
+        state: "{{ state_attr('sensor.rct_battery_cells_json', 'module_1_avg_mv') }}"
+      - name: "RCT Module 1 Cell Voltage Spread"
+        unique_id: rct_module_1_cell_voltage_spread
+        unit_of_measurement: "mV"
+        state_class: measurement
+        availability: "{{ state_attr('sensor.rct_battery_cells_json', 'module_1_spread_mv') is not none }}"
+        state: "{{ state_attr('sensor.rct_battery_cells_json', 'module_1_spread_mv') }}"
+      - name: "RCT Module 1 Cycles"
+        unique_id: rct_module_1_cycles
+        state_class: total_increasing
+        availability: "{{ state_attr('sensor.rct_battery_cells_json', 'module_1_cycles') is not none }}"
+        state: "{{ state_attr('sensor.rct_battery_cells_json', 'module_1_cycles') }}"

--- a/rct.py
+++ b/rct.py
@@ -67,6 +67,12 @@ Valid Parameters:
   p_rec_lim[1]                    Max. battery to grid power (0-6000)
   power_mng.use_grid_power_enable Enable/disable grid power usage (TRUE/FALSE)
   buf_v_control.power_reduction   External power reduction (0.000-1.000)
+  battery.soc_target              Current SOC target (0.00-1.00; get/set)
+  battery.soc_target_high         SOC target band upper bound (get only —
+                                  firmware output, useful for diagnostics)
+  battery.soc_target_low          SOC target band lower bound (get only)
+  power_mng.bat_next_calib_date   Next battery calibration (unix timestamp;
+                                  set ~2 days in the past to start one now)
 """)
 
 
@@ -170,6 +176,8 @@ def set_value(parameter: str, value: str, host: str) -> str:
         "p_rec_lim[1]",
         "power_mng.use_grid_power_enable",
         "buf_v_control.power_reduction",
+        "battery.soc_target",
+        "power_mng.bat_next_calib_date",
     ]
 
     if parameter not in valid_parameters:
@@ -217,6 +225,21 @@ def set_value(parameter: str, value: str, host: str) -> str:
     elif parameter == "buf_v_control.power_reduction":
         value = validate_float(parameter, value, 0.0, 1.0, decimals=3)
 
+    elif parameter == "battery.soc_target":
+        value = validate_float(parameter, value, 0.0, 1.0)
+
+    elif parameter == "power_mng.bat_next_calib_date":
+        # Unix timestamp of the next scheduled battery calibration. Setting a
+        # date ~2 days in the past starts a calibration immediately (the
+        # battery icon shows "Charge Calib" and the SOC target goes to 100 %).
+        try:
+            value = int(value)
+            if not (1_000_000_000 <= value <= 4_102_444_800):
+                raise ValueError
+        except ValueError:
+            print(f"Error: '{value}' must be a unix timestamp (2001-2100).")
+            sys.exit(1)
+
     # Prepare and send frame
     host_port = (host, DEFAULT_PORT)
     object_info = REGISTRY.get_by_name(parameter)
@@ -242,6 +265,10 @@ def get_value(parameter: str, host: str) -> str:
         "p_rec_lim[1]",
         "power_mng.use_grid_power_enable",
         "buf_v_control.power_reduction",
+        "battery.soc_target",
+        "battery.soc_target_high",
+        "battery.soc_target_low",
+        "power_mng.bat_next_calib_date",
     ]
 
     if parameter not in valid_parameters:

--- a/rct_cells.py
+++ b/rct_cells.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""RCT battery cell-level monitor.
+
+Reads live per-cell voltages and temperatures for every battery module plus
+stack-level health registers over ONE TCP connection and prints a one-line
+JSON document — ready to be consumed by a Home Assistant command_line sensor
+(see packages/rctpower_cells.yaml) or any other collector.
+
+The undocumented `battery.cells[N]` payload decodes as 24 records of
+4 bytes per module:
+
+    [temperature_c: uint8][voltage_mv: uint16 little-endian][flag: uint8]
+
+(verified against `battery.min_cell_voltage` / `battery.max_cell_voltage`
+and `battery.temperature` on a Power Storage 6.0 with 4 battery modules).
+
+Every response frame is validated against the requested object id and its
+CRC before being decoded — the inverter shares one stream with unsolicited
+frames and can deliver responses meant for other connected clients (see
+python-rctclient issue #43), so an unvalidated read may silently return a
+value belonging to a different register.
+
+Optionally pushes per-cell series in Prometheus text format to a
+`/api/v1/import/prometheus` endpoint (VictoriaMetrics and compatible) for
+long-term cell-aging records:
+
+    rct_cell_voltage_mv{module="1",cell="07"} 3301
+
+Usage: rct_cells.py --host=<ip> [--modules=4] [--vm-url=http://host:8428]
+"""
+import json
+import socket
+import sys
+import time
+import urllib.request
+
+from rctclient.exceptions import FrameCRCMismatch
+from rctclient.frame import make_frame, ReceiveFrame
+from rctclient.registry import REGISTRY
+from rctclient.types import Command
+from rctclient.utils import decode_value
+
+HOST = None
+VM_URL = None
+MODULES = 4
+
+for arg in sys.argv[1:]:
+    if arg.startswith("--host="):
+        HOST = arg.split("=", 1)[1]
+    elif arg.startswith("--vm-url="):
+        VM_URL = arg.split("=", 1)[1]
+    elif arg.startswith("--modules="):
+        MODULES = int(arg.split("=", 1)[1])
+
+if not HOST:
+    print("Error: --host=<ip> required", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_register(sock, oi, timeout=10, raw=False):
+    """Read one register on an open socket; id+CRC validated. None on timeout."""
+    sock.send(make_frame(command=Command.READ, id=oi.object_id))
+    deadline = time.monotonic() + timeout
+    pending = b""
+    frame = ReceiveFrame()
+    while time.monotonic() < deadline:
+        if pending:
+            chunk, pending = pending, b""
+        else:
+            try:
+                chunk = sock.recv(1024)
+            except socket.timeout:
+                return None
+            if not chunk:
+                return None
+        try:
+            consumed = frame.consume(chunk)
+        except FrameCRCMismatch as e:
+            # Resync past the corrupt frame, keep the tail.
+            consumed = getattr(e, "consumed_bytes", 0) or 1
+            frame = ReceiveFrame()
+            pending = chunk[consumed:]
+            continue
+        pending = chunk[consumed:]
+        if frame.complete():
+            done, frame = frame, ReceiveFrame()
+            if not done.crc_ok or done.id != oi.object_id:
+                continue
+            if raw:
+                return done.data
+            return decode_value(oi.response_data_type, done.data)
+    return None
+
+
+def read_retry(sock, name, retries=3, raw=False):
+    oi = REGISTRY.get_by_name(name)
+    for _ in range(retries):
+        val = read_register(sock, oi, raw=raw)
+        if val is not None:
+            return val
+        time.sleep(1)
+    return None
+
+
+def decode_cells(blob):
+    """battery.cells[N] payload: 24 records of [temp_c u8][voltage_mv u16 LE][flag u8]."""
+    cells = []
+    for i in range(0, len(blob) - 3, 4):
+        cells.append(
+            {
+                "temp_c": blob[i],
+                "mv": int.from_bytes(blob[i + 1 : i + 3], "little"),
+                "flag": blob[i + 3],
+            }
+        )
+    return cells
+
+
+modules = {}
+scalars = {}
+with socket.create_connection((HOST, 8899), timeout=10) as sock:
+    sock.settimeout(10)
+    for m in range(MODULES):
+        blob = read_retry(sock, f"battery.cells[{m}]", raw=True)
+        if blob:
+            modules[m] = decode_cells(blob)
+        time.sleep(0.3)
+    for name, key in [
+        ("battery.min_cell_voltage", "bms_min_cell_v"),
+        ("battery.max_cell_voltage", "bms_max_cell_v"),
+        ("battery.ah_capacity", "ah_capacity"),
+        ("battery.soh", "soh"),
+        ("battery.soc", "soc"),
+        ("battery.temperature", "battery_temp_c"),
+        ("battery.soc_update_since", "soc_update_since"),
+    ]:
+        val = read_retry(sock, name)
+        if val is not None:
+            scalars[key] = round(float(val), 4)
+        time.sleep(0.3)
+    for m in range(MODULES):
+        val = read_retry(sock, f"battery.stack_cycles[{m}]")
+        if val is not None:
+            scalars[f"module_{m + 1}_cycles"] = int(val)
+        time.sleep(0.3)
+
+if not modules:
+    print("Error: no cell data read", file=sys.stderr)
+    sys.exit(1)
+
+# --- stack + per-module aggregates ---
+all_mv = [c["mv"] for cells in modules.values() for c in cells]
+out = {
+    "cell_min_mv": min(all_mv),
+    "cell_max_mv": max(all_mv),
+    "cell_spread_mv": max(all_mv) - min(all_mv),
+    "cells_read": len(all_mv),
+    **scalars,
+}
+for m, cells in modules.items():
+    mvs = [c["mv"] for c in cells]
+    out[f"module_{m + 1}_min_mv"] = min(mvs)
+    out[f"module_{m + 1}_max_mv"] = max(mvs)
+    out[f"module_{m + 1}_avg_mv"] = round(sum(mvs) / len(mvs), 1)
+    out[f"module_{m + 1}_spread_mv"] = max(mvs) - min(mvs)
+
+# --- optional per-cell push, Prometheus text format (best effort) ---
+if VM_URL:
+    lines = []
+    for m, cells in modules.items():
+        for i, c in enumerate(cells):
+            labels = f'module="{m + 1}",cell="{i + 1:02d}"'
+            lines.append(f"rct_cell_voltage_mv{{{labels}}} {c['mv']}")
+            lines.append(f"rct_cell_temp_c{{{labels}}} {c['temp_c']}")
+            if c["flag"]:
+                lines.append(f"rct_cell_flag{{{labels}}} {c['flag']}")
+    for key, val in scalars.items():
+        lines.append(f"rct_battery_{key} {val}")
+    lines.append(f"rct_battery_cell_spread_mv {out['cell_spread_mv']}")
+    try:
+        req = urllib.request.Request(
+            VM_URL.rstrip("/") + "/api/v1/import/prometheus",
+            data="\n".join(lines).encode(),
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=10)
+        out["vm_push"] = "ok"
+    except Exception as exc:  # push failure must not fail the JSON output
+        out["vm_push"] = f"failed: {exc}"
+
+print(json.dumps(out))

--- a/rct_cells.py
+++ b/rct_cells.py
@@ -59,7 +59,7 @@ if not HOST:
 
 def read_register(sock, oi, timeout=10, raw=False):
     """Read one register on an open socket; id+CRC validated. None on timeout."""
-    sock.send(make_frame(command=Command.READ, id=oi.object_id))
+    sock.sendall(make_frame(command=Command.READ, id=oi.object_id))
     deadline = time.monotonic() + timeout
     pending = b""
     frame = ReceiveFrame()
@@ -123,7 +123,11 @@ with socket.create_connection((HOST, 8899), timeout=10) as sock:
     for m in range(MODULES):
         blob = read_retry(sock, f"battery.cells[{m}]", raw=True)
         if blob:
-            modules[m] = decode_cells(blob)
+            cells = decode_cells(blob)
+            # A too-short payload decodes to [] — storing it would crash the
+            # min()/max() aggregates below, so keep non-empty modules only.
+            if cells:
+                modules[m] = cells
         time.sleep(0.3)
     for name, key in [
         ("battery.min_cell_voltage", "bms_min_cell_v"),


### PR DESCRIPTION
Adds **battery cell-level monitoring** — functionality that (as far as I can tell) doesn't exist anywhere in the RCT community tooling yet, because the `battery.cells[N]` register format was undocumented.

## What's in here

### `rct_cells.py` — per-cell monitor
Reads live per-cell voltages and temperatures of every battery module plus stack health registers (`ah_capacity`, `soh`, `soc`, per-module `stack_cycles[n]`) over **one** TCP connection and prints a single JSON line:

```
$ python rct_cells.py --host=192.168.0.99 --modules=4
{"cell_min_mv": 3292, "cell_max_mv": 3330, "cell_spread_mv": 38, "cells_read": 96, "ah_capacity": 16.138, "soh": 1.0, ...}
```

The `battery.cells[N]` payload decodes as 24 records of 4 bytes per module: `[temperature_c: uint8][voltage_mv: uint16 LE][flag: uint8]` — verified against `battery.min_cell_voltage` / `battery.max_cell_voltage` and `battery.temperature` on a Power Storage 6.0 with 4 modules. Every response frame is validated against the requested object id + CRC (same protocol quirk as #45, handled independently here).

Optional `--vm-url=` pushes every cell in Prometheus text format (`rct_cell_voltage_mv{module="1",cell="07"} 3301`) to VictoriaMetrics or anything exposing `/api/v1/import/prometheus`, for long-term cell-aging records.

### `packages/rctpower_cells.yaml`
Ready-made Home Assistant package: command_line sensor (15-min polling) + template sensors with `state_class` for long-term statistics.

### `rct.py` whitelist additions
- `battery.soc_target` (get/set)
- `battery.soc_target_high` / `battery.soc_target_low` (get — firmware outputs, diagnostics)
- `power_mng.bat_next_calib_date` (get/set) — set a date ~2 days in the past and the inverter starts a battery calibration immediately ("Charge Calib"), the community-proven recipe from photovoltaikforum threads 196410/250930.

## Why this matters

Cell **imbalance** silently eats usable capacity: the BMS `ah_capacity` estimate shrinks while `soh` stays 1.0. On my system (battery extension: modules 1–3 at 859 cycles, module 4 at 170) the estimate fell 20.0 → 16.1 Ah in 10 months — and the per-module view made the cause visible in one glance: the newer module runs ~25 mV above the old ones and terminates charging for the whole stack early. A healthy pack sits < ~25 mV spread; ≥50 mV is documentation-worthy for a warranty case.

Tested live on a Power Storage 6.0 (BMS 5615), rctclient 0.0.6; the code only uses `ReceiveFrame`/`decode_value` APIs present in the pinned 0.0.3 as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
