### PR TITLE
fix: surface failed writes and reads via non-zero exit codes

### DIFF
--- a/rct.py
+++ b/rct.py
@@ -88,8 +88,13 @@ def validate_float(
         sys.exit(1)
 
 
-def send_data(host_port: tuple[str, int], data: bytes) -> None:
-    """Send a prepared binary frame to the inverter."""
+def send_data(host_port: tuple[str, int], data: bytes) -> bool:
+    """Send a prepared binary frame to the inverter.
+
+    Returns True on success, False on socket error / timeout, so callers can
+    surface the failure instead of reporting success for a write that never
+    reached the inverter.
+    """
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.settimeout(5)
@@ -97,10 +102,13 @@ def send_data(host_port: tuple[str, int], data: bytes) -> None:
             sock.connect(host_port)
             sock.sendall(data)
             print("*** Data sent successfully.")
+            return True
     except (socket.timeout, socket.error) as e:
         print(f"### ERROR ### Socket error: {e}")
+        return False
     except Exception as e:
         print(f"### ERROR ### Unexpected error: {e}")
+        return False
     finally:
         print("*** Socket closed.")
 
@@ -224,7 +232,11 @@ def set_value(parameter: str, value: str, host: str) -> str:
     frame = make_frame(
         command=Command.WRITE, id=object_info.object_id, payload=encoded_value
     )
-    send_data(host_port, frame)
+    if not send_data(host_port, frame):
+        # Exit non-zero so automation callers (e.g. a Home Assistant
+        # shell_command) register the failure instead of a false success.
+        print(f"### ERROR ### Write failed for {parameter} = {value} on {host}")
+        sys.exit(1)
 
     return f"*** SET SUCCESS: {parameter} = {value} on {host}"
 
@@ -256,7 +268,10 @@ def get_value(parameter: str, host: str) -> str:
 
     if result is not None:
         return f"*** READ SUCCESS: {parameter} = {result}"
-    return f"### ERROR ### Failed to read parameter '{parameter}'"
+    # Exit non-zero so callers (command_line sensors, scripts) can tell a
+    # failed read apart from a value.
+    print(f"### ERROR ### Failed to read parameter '{parameter}' on {host}")
+    sys.exit(1)
 
 
 # ============================================================================


### PR DESCRIPTION
`set_value` printed `SET SUCCESS` even when the socket write failed (`send_data` swallowed the exception and returned nothing), and `get_value` returned its error string with exit code 0. Automation callers — a Home Assistant `shell_command`, a `command_line` sensor, a cron script — therefore saw success for operations that never reached the inverter, and the assumed inverter state silently drifted from reality.

Changes:
- `send_data` returns `True`/`False` instead of `None`
- `set_value` exits 1 when the write did not reach the inverter
- `get_value` exits 1 when all read attempts failed

Running this way in production for months on a Power Storage 6.0 — the non-zero exit is what lets our drift-recovery automation notice and re-issue lost writes.

Independent of #45 and #46; happy to rebase whichever lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
